### PR TITLE
remove collectAsList call

### DIFF
--- a/src/main/java/com/teragrep/functions/dpf_02/BatchCollect.java
+++ b/src/main/java/com/teragrep/functions/dpf_02/BatchCollect.java
@@ -114,18 +114,18 @@ public final class BatchCollect extends SortOperation {
             }
         }
 
-        List<Row> collected = orderDataset(batchDF).limit(numberOfRows).collectAsList();
-        Dataset<Row> createdDsFromCollected = SparkSession.builder().getOrCreate().createDataFrame(collected, this.inputSchema);
+        // sort dataset and limit
+        Dataset<Row> orderedAndLimitedDs = orderDataset(batchDF).limit(numberOfRows);
 
+        // union with previous data
         if (this.savedDs == null) {
-            this.savedDs = createdDsFromCollected;
+            this.savedDs = orderedAndLimitedDs;
         }
         else {
-            this.savedDs = savedDs.union(createdDsFromCollected);
+            this.savedDs = savedDs.union(orderedAndLimitedDs);
         }
 
         this.savedDs = orderDataset(this.savedDs).limit(numberOfRows);
-
     }
 
     // Call this instead of collect to skip limiting (for aggregatesUsed=true)


### PR DESCRIPTION
Removes the collectAsList call from BatchCollect.
Might be a possible culprit for order changing even without providing a sorting column.