### PR TITLE
Post batch collect processing support

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'temurin'
           server-id: github
           settings-path: ${{ github.workspace }}

--- a/.github/workflows/upload_release.yaml
+++ b/.github/workflows/upload_release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Signing
         uses: actions/setup-java@v2
         with:
-          java-version: 8.0.292+10
+          java-version: 11
           distribution: 'adopt'
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
@@ -29,7 +29,7 @@ jobs:
       - name: Setup GitHub Packages
         uses: actions/setup-java@v2
         with:
-          java-version: 8.0.292+10
+          java-version: 11
           distribution: 'adopt'
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Maven Central
         uses: actions/setup-java@v2
         with:
-          java-version: 8.0.292+10
+          java-version: 11
           distribution: 'adopt'
 
           server-id: central-sonatype-org

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <revision>0.0.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <sha1/>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.12</artifactId>
-      <version>2.4.5</version>
+      <version>3.4.0</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.12</artifactId>
-      <version>2.4.5</version>
+      <version>3.4.0</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -121,7 +121,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <source>8</source>
+              <source>11</source>
             </configuration>
           </execution>
         </executions>
@@ -174,8 +174,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/teragrep/functions/dpf_02/AbstractStep.java
+++ b/src/main/java/com/teragrep/functions/dpf_02/AbstractStep.java
@@ -1,0 +1,93 @@
+/*
+ * Teragrep Batch Collect DPF-02
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.functions.dpf_02;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.streaming.StreamingQueryException;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class AbstractStep {
+
+    public enum CommandProperty {
+        USES_INTERNAL_BATCHCOLLECT, // Command has an internal batch collect, e.g. sort
+        IGNORE_DEFAULT_SORTING, // Command applies a certain order to the rows
+        SEQUENTIAL_ONLY, // Works only in Sequential mode (forEachBatch)
+        AGGREGATE, // If there are multiple aggregate commands, switch to sequential mode is necessary
+        REQUIRE_PRECEDING_AGGREGATE, // this command requires an aggregate command before it
+        NO_PRECEDING_AGGREGATE, // command does not allow an aggregate command before it
+        POST_BATCHCOLLECT, // command should be run post (after) batch collect
+    }
+
+    protected final Set<CommandProperty> properties = new HashSet<>();
+    protected boolean aggregatesUsedBefore = false;
+
+    public boolean hasProperty(CommandProperty prop) {
+        return properties.contains(prop);
+    }
+
+    private boolean addProperty(CommandProperty prop) {
+        return properties.add(prop);
+    }
+
+    public void setAggregatesUsedBefore(boolean aggregatesUsedBefore) {
+        this.aggregatesUsedBefore = aggregatesUsedBefore;
+    }
+
+    public AbstractStep() {
+
+    }
+
+    /**
+     * Perform the necessary dataframe operations for the implemented command
+     * 
+     * @param dataset Dataset to operate on
+     * @return Dataframe, which has the operations applied
+     */
+    public abstract Dataset<Row> get(Dataset<Row> dataset) throws StreamingQueryException;
+}

--- a/src/main/java/com/teragrep/functions/dpf_02/BatchCollect.java
+++ b/src/main/java/com/teragrep/functions/dpf_02/BatchCollect.java
@@ -66,14 +66,14 @@ public final class BatchCollect extends SortOperation {
     private boolean sortedBySingleColumn = false;
 
     public BatchCollect(String sortColumn, int defaultLimit) {
-        this(sortColumn, defaultLimit, new ArrayList<>());
+        this(sortColumn, defaultLimit, 0, new ArrayList<>());
     }
 
-    public BatchCollect(String sortColumn, int defaultLimit, List<SortByClause> listOfSortByClauses) {
-        this(sortColumn, defaultLimit, listOfSortByClauses, 0);
+    public BatchCollect(String sortColumn, int defaultLimit, int postBcLimit) {
+        this(sortColumn, defaultLimit, postBcLimit, new ArrayList<>());
     }
 
-    public BatchCollect(String sortColumn, int defaultLimit, List<SortByClause> listOfSortByClauses, int postBcLimit) {
+    public BatchCollect(String sortColumn, int defaultLimit, int postBcLimit, List<SortByClause> listOfSortByClauses) {
         super(listOfSortByClauses);
         LOGGER.info("Initialized BatchCollect based on column <[{}]> and a limit of <[{}]> row(s). SortByClauses included: <[{}]>. Post batchcollect limit of <[{}]> row(s)",
                 sortColumn, defaultLimit, (listOfSortByClauses != null ? listOfSortByClauses.size() : "null"), postBcLimit);

--- a/src/test/java/BatchCollectTest.java
+++ b/src/test/java/BatchCollectTest.java
@@ -263,12 +263,7 @@ public class BatchCollectTest {
         return rowDataset
                 .writeStream()
                 .foreachBatch(
-                        new VoidFunction2<Dataset<Row>, Long>() {
-                            @Override
-                            public void call(Dataset<Row> batchDF, Long batchId) {
-                                batchCollect.call(batchDF, batchId, skipLimiting);
-                            }
-                        }
+                        (VoidFunction2<Dataset<Row>, Long>) (batchDF, batchId) -> batchCollect.call(batchDF, batchId, skipLimiting)
                 )
                 .outputMode("append")
                 .start();

--- a/src/test/java/BatchCollectTest.java
+++ b/src/test/java/BatchCollectTest.java
@@ -100,7 +100,7 @@ public class BatchCollectTest {
         MemoryStream<Row> rowMemoryStream =
                 new MemoryStream<>(1, sqlContext, Option.apply(1), encoder);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 100, null);
+        BatchCollect batchCollect = new BatchCollect("_time", 100);
         Dataset<Row> rowDataset = rowMemoryStream.toDF();
         StreamingQuery streamingQuery = Assertions.assertDoesNotThrow(() -> startStream(rowDataset, batchCollect, false, Collections.emptyList()));
 
@@ -168,7 +168,7 @@ public class BatchCollectTest {
         MemoryStream<Row> rowMemoryStream =
                 new MemoryStream<>(1, sqlContext, Option.apply(1), encoder);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 5, new ArrayList<>());
+        BatchCollect batchCollect = new BatchCollect("_time", 5);
         Dataset<Row> rowDataset = rowMemoryStream.toDF();
 
         // Skip limiting here
@@ -242,7 +242,7 @@ public class BatchCollectTest {
         MemoryStream<Row> rowMemoryStream =
                 new MemoryStream<>(1, sqlContext, Option.apply(1), encoder);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 100, null);
+        BatchCollect batchCollect = new BatchCollect("_time", 100);
         Dataset<Row> rowDataset = rowMemoryStream.toDF();
         StreamingQuery streamingQuery = Assertions.assertDoesNotThrow(() -> startStream(rowDataset, batchCollect, false,
                 Collections.singletonList(new TestAggregationStep())));

--- a/src/test/java/BatchCollectTest.java
+++ b/src/test/java/BatchCollectTest.java
@@ -291,7 +291,7 @@ public class BatchCollectTest {
         Dataset<Row> collectedAsDF = batchCollect.getCollectedAsDataframe();
         Assertions.assertEquals(1, collectedAsDF.count());
 
-        Assertions.assertEquals(100L, collectedAsDF.first().getLong(0));
+        Assertions.assertEquals(201L, collectedAsDF.first().getLong(0));
     }
 
     private Seq<Row> makeRows(Timestamp _time,

--- a/src/test/java/SortOperationTest.java
+++ b/src/test/java/SortOperationTest.java
@@ -342,7 +342,7 @@ public class SortOperationTest {
                         new VoidFunction2<Dataset<Row>, Long>() {
                             @Override
                             public void call(Dataset<Row> batchDF, Long batchId) throws Exception {
-                                batchCollect.collect(batchDF, batchId);
+                                batchCollect.collect(batchDF, batchId, Collections.emptyList(), false);
                             }
                         }
                 )

--- a/src/test/java/SortOperationTest.java
+++ b/src/test/java/SortOperationTest.java
@@ -107,7 +107,7 @@ public class SortOperationTest {
         sortByClauses.add(partSbc);
         sortByClauses.add(offSbc);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 20, sortByClauses);
+        BatchCollect batchCollect = new BatchCollect("_time", 20, 0, sortByClauses);
 
         createData(batchCollect, sqlContext);
 
@@ -145,7 +145,7 @@ public class SortOperationTest {
         sortByClauses.add(partSbc);
         sortByClauses.add(offSbc);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 20, sortByClauses);
+        BatchCollect batchCollect = new BatchCollect("_time", 20,0, sortByClauses);
 
         createData(batchCollect, sqlContext);
 
@@ -183,7 +183,7 @@ public class SortOperationTest {
         sortByClauses.add(partSbc);
         sortByClauses.add(ipSbc);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 20, sortByClauses);
+        BatchCollect batchCollect = new BatchCollect("_time", 20,0, sortByClauses);
 
         createData(batchCollect, sqlContext);
 
@@ -230,7 +230,7 @@ public class SortOperationTest {
         sortByClauses.add(hostSbc);
         sortByClauses.add(offSbc);
 
-        BatchCollect batchCollect = new BatchCollect("_time", 20, sortByClauses);
+        BatchCollect batchCollect = new BatchCollect("_time", 20,0, sortByClauses);
 
         createData(batchCollect, sqlContext);
 

--- a/src/test/java/TestAggregationStep.java
+++ b/src/test/java/TestAggregationStep.java
@@ -1,0 +1,57 @@
+import com.teragrep.functions.dpf_02.AbstractStep;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.streaming.StreamingQueryException;
+
+/*
+ * Teragrep Batch Collect DPF-02
+ * Copyright (C) 2019, 2020, 2021, 2022  Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://github.com/teragrep/teragrep/blob/main/LICENSE>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+public final class TestAggregationStep extends AbstractStep {
+    @Override
+    public Dataset<Row> get(final Dataset<Row> dataset) throws StreamingQueryException {
+        return dataset.agg(functions.count("_raw"));
+    }
+}


### PR DESCRIPTION
Fixes issue
* #33 

Changes
* GitHub workflows now use JDK 11 instead of JDK 8
* Builds now using JDK 11 instead of JDK 8
* Changed Spark 2.x version to 3.4.0 in pom.xml
* AbstractStep was moved from pth_10 to dpf_02 project (to avoid pth_10 being a dependency in dpf_02)
* BatchCollect was slightly cleaned up
* Added support for providing post batchcollect steps to be run
* Added testing aggregation step to test post batchcollect step processing